### PR TITLE
Lyft apprenticeship is no longer available

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ So without further ago, here's a list of developer & design apprenticeship oppor
 * [LaunchCode](https://www.launchcode.org/)
 * [LEAP](http://industryexplorers.com)
 * [LinkedIn Reach](https://careers.linkedin.com/reach)
-* [Lyft](https://betalist.com/jobs/186175-software-engineering-apprenticeship-at-lyft)
 * [MAXX Potential](https://maxxpotential.com/)
 * [Moove-it](https://moove-it.com/web-development-apprenticeship)
 * [Pillar Technology](http://pillartechnology.com/careers)
@@ -79,3 +78,4 @@ Or just [create an issue](https://github.com/fvcproductions/apprenticeships/issu
 * [FVCproductions](https://github.com/fvcproductions) 🍓🍫
 * [Benjamin Modayil](https://modayil.me)
 * [Leilani Raranga](https://linkedin.com/in/leilanir)
+* [Colton Hurst](https://www.coltonhurst.com)


### PR DESCRIPTION
Unfortunately, looks like the Lyft job is no longer available. As stated in the readme, it may have just been a seasonal thing, but the link seems to be a link to a specific job that has passed, rather than a page where the jobs are posted.

However, if that's wrong, and that really is the right page, my bad! Just trying to help :)