### PR TITLE
removed a100.md

### DIFF
--- a/content/apprenticeships/a100.md
+++ b/content/apprenticeships/a100.md
@@ -1,8 +1,0 @@
----
-company: "A100"
-link: "http://indie-soft.com/a100/"
-location:
-  - "New Haven, CT"
-description: "A100 is a software apprenticeship program that provides technical training to aspiring software developers, then matches them with paid internships at local startups."
-draft: false
----


### PR DESCRIPTION
The link for a100.md does not lead to an apprenticeship listing but a furniture site. I haven't been able to find the listing on Google.

The link: http://indie-soft.com/a100/

Issue link: #28 
---


## ✅️ By submitting this PR, I have verified the following

* [✅️] Checked to see if a similar PR has already been opened 🤔️
* [✅️] Reviewed the contributing guidelines 🔍️
* [✅️] Added my name to the bottom of the list under the **Credits** section in the `README.md` with a link to my website or GitHub profile 👥️